### PR TITLE
Fix periodically updating reference speed

### DIFF
--- a/train-controller/src/main/java/hu/bme/mit/train/controller/TrainControllerImpl.java
+++ b/train-controller/src/main/java/hu/bme/mit/train/controller/TrainControllerImpl.java
@@ -8,6 +8,16 @@ public class TrainControllerImpl implements TrainController {
 	private int referenceSpeed = 0;
 	private int speedLimit = 0;
 
+	public TrainControllerImpl() {
+		Timer timer = Timer();
+		timer.scheduleAtFixedRate(new TimerTask() {
+			@Override
+			public void run() {
+				followSpeed();
+			}
+		}, 1000, 500)
+	}
+
 	@Override
 	public void followSpeed() {
 		if (referenceSpeed < 0) {


### PR DESCRIPTION
Periodically call followSpeed() in TrainController to maintain reference speed, scheduled by a timer service.